### PR TITLE
Add small fixes related to ruby 2.7 update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN set -xe; \
         mariadb-connector-c-dev \
         mariadb-dev \
         sqlite-dev; \
-    export PATH=/lobsters/.gem/ruby/2.3.0/bin:$PATH; \
+    export PATH=/lobsters/.gem/ruby/2.7.0/bin:$PATH; \
     export SUPATH=$PATH; \
     export GEM_HOME="/lobsters/.gem"; \
     export GEM_PATH="/lobsters/.gem"; \
@@ -47,7 +47,7 @@ RUN set -xe; \
     cd /lobsters; \
     su lobsters -c "gem install bundler --user-install"; \
     su lobsters -c "gem update"; \
-    su lobsters -c "gem install rake -v 12.3.2"; \
+    su lobsters -c "gem install rake -v 13.0.1"; \
     su lobsters -c "bundle install --no-cache"; \
     if [ "${DEVELOPER_BUILD,,}" != "true" ]; \
     then \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ REPO_NAMESPACE          ?= utensils
 REPO_USERNAME           ?= jamesbrink
 REPO_API_URL            ?= https://hub.docker.com/v2
 IMAGE_NAME              ?= lobsters
-BASE_IMAGE              ?= ruby:2.3-alpine
+BASE_IMAGE              ?= ruby:2.7-alpine
 DEVELOPER_BUILD         ?= false
 VERSION                 := $(shell git describe --tags --abbrev=0 2>/dev/null || git rev-parse --abbrev-ref HEAD 2>/dev/null)
 VCS_REF                 := $(shell git rev-parse --short HEAD 2>/dev/null || echo "0000000")

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 This repo contains a working example of how to use and deploy [Lobsters][lobsters] within a Docker environment.  
 I have decided to create this project to assist anyone else wanting to get started with Lobsters quickly using Docker.
 
-This image is built off of the official Ruby Docker image ([ruby:2.3-alpine][ruby-alpine])
+This image is built off of the official Ruby Docker image ([ruby:2.7-alpine][ruby-alpine])
 
 ## Quick Start
 


### PR DESCRIPTION
Updated the README.md to reference new ruby version.
Updated the Makefilew to use ruby:2.7 as default base image.
Updated the Dockerfile to use 2.7 gems path and bumped rake to 13.0.1